### PR TITLE
More failproof way to import CocoaSecurity.h

### DIFF
--- a/SecureNSUserDefaults/SecureNSUserDefaults/NSUserDefaults+SecureAdditions.m
+++ b/SecureNSUserDefaults/SecureNSUserDefaults/NSUserDefaults+SecureAdditions.m
@@ -7,7 +7,7 @@
 //
 
 #import "NSUserDefaults+SecureAdditions.h"
-#import <CocoaSecurity/CocoaSecurity.h>
+#import "CocoaSecurity.h"
 
 #define kStoredObjectKey              @"storedObject"
 


### PR DESCRIPTION
Pretty please?
