### PR TITLE
Return nil if existing `objectForKey:` is not an NSData object

### DIFF
--- a/SecureNSUserDefaults/SecureNSUserDefaults/NSUserDefaults+SecureAdditions.m
+++ b/SecureNSUserDefaults/SecureNSUserDefaults/NSUserDefaults+SecureAdditions.m
@@ -121,7 +121,7 @@ static NSString *_secret = nil;
     NSData *data = [self objectForKey:defaultName];
     
     // Check if we have some data to decrypt, return nil if no
-    if(data == nil) {
+    if(data == nil || ![data isKindOfClass:[NSData class]]) {
         return nil;
     }
     


### PR DESCRIPTION
During migration phase, we have an issue where the user does a partial update of the app, and we start reading from the old `NSUserDefaults` plist before we can update its values to the encrypted version. This causes a crash on line 137 
`CocoaSecurityResult *result = [CocoaSecurity aesDecryptWithData:data key:aesKey iv:aesIv];` 
where the `data` object is actually an NSString (other other object types) underneath.

Updating to verify `data` is of class `NSData` before passing it down for decryption.
